### PR TITLE
Fix Multi-requests to inat api to get a Taxa Image URL.

### DIFF
--- a/src/frontend/src/components/Sidebar.js
+++ b/src/frontend/src/components/Sidebar.js
@@ -16,6 +16,7 @@ const Sidebar = forwardRef((props, ref) => {
   const [speciesData, setSpeciesData] = useState({ name: "", common_name: "" });
   const [taxaName, setTaxaName] = useState("");
   const [imgURL, setImgURL] = useState("/static/inat_logo_square.png");
+  const [updateImgURL, setUpdateImgURL] = useState(false);
 
   useEffect(() => {
     // Fetch taxa names from the JSON file and initialize auto-suggest
@@ -37,6 +38,7 @@ const Sidebar = forwardRef((props, ref) => {
           },
           select: function (event, ui) {
             setTaxaName(ui.item.value);
+            setUpdateImgURL(true);
           },
         });
       })
@@ -63,14 +65,15 @@ const Sidebar = forwardRef((props, ref) => {
   }, 500);
 
   useEffect(() => {
-    if (taxaName) {
+    if (taxaName && updateImgURL) {
       const regExp = /\(([^)]+)\)/;
       const taxaMatch = taxaName.match(regExp);
       if (taxaMatch) {
         debouncedFetch(taxaMatch[1]);
+        setUpdateImgURL(false);
       }
     }
-  }, [taxaName, debouncedFetch]);
+  }, [taxaName, updateImgURL, debouncedFetch]);
 
   return (
     <div className="sidebar">


### PR DESCRIPTION
For any user action on the page, if the taxa name was already selected by the user, then a repeated request was sent to the API. 
This can be seen in the browser console.

![image](https://github.com/user-attachments/assets/4dd3ecc5-ccc2-4498-90f7-baa740d658b9)

