### PR TITLE
Hide the `disable_ocean_mask` checkbox from the UI to avoid user confusion.

### DIFF
--- a/src/frontend/src/App.js
+++ b/src/frontend/src/App.js
@@ -91,7 +91,7 @@ function App() {
       hex_resolution: Number(formRefs.hexResolution.current.value),
       threshold: Number(formRefs.threshold.current.value),
       model: formRefs.model.current.value,
-      disable_ocean_mask: formRefs.disableOceanMask.current.checked,
+      disable_ocean_mask: formRefs.disableOceanMask.current ? formRefs.disableOceanMask.current.checked : false,
     };
 
     if (!checkTaxaValid(formData.taxa_name)) {
@@ -134,7 +134,7 @@ function App() {
       hex_resolution: Number(formRefs.hexResolution.current.value),
       threshold: Number(formRefs.threshold.current.value),
       model: formRefs.model.current.value,
-      disable_ocean_mask: formRefs.disableOceanMask.current.checked,
+      disable_ocean_mask: formRefs.disableOceanMask.current ? formRefs.disableOceanMask.current.checked : false,
       annotation_hexagon_ids: annotationHexagonIDs,
     };
 
@@ -179,7 +179,7 @@ function App() {
       hex_resolution: Number(formRefs.hexResolution.current.value),
       threshold: Number(formRefs.threshold.current.value),
       model: formRefs.model.current.value,
-      disable_ocean_mask: formRefs.disableOceanMask.current.checked,
+      disable_ocean_mask: formRefs.disableOceanMask.current ? formRefs.disableOceanMask.current.checked : false,
     };
 
     fetch(`${API_URL}/load_annotation/`, {

--- a/src/frontend/src/components/Sidebar.js
+++ b/src/frontend/src/components/Sidebar.js
@@ -11,6 +11,8 @@ const debounce = (func, wait) => {
   };
 };
 
+const SHOW_DISABLE_OCEAN_MASK_CHECKBOX = false;
+
 const Sidebar = forwardRef((props, ref) => {
   console.log('Render sidebar');
 
@@ -127,6 +129,7 @@ const Sidebar = forwardRef((props, ref) => {
         readOnly={true}
       />
 
+      { SHOW_DISABLE_OCEAN_MASK_CHECKBOX &&
       <div className="checkbox-container">
         <input
           type="checkbox"
@@ -136,6 +139,7 @@ const Sidebar = forwardRef((props, ref) => {
         />
         <label htmlFor="disable_ocean_mask"> Disable Ocean Mask</label>
       </div>
+      }
 
       <div className="taxa-info">
         <img src={imgURL} alt="species_default_image" />


### PR DESCRIPTION
Users were unsure of the purpose of this checkbox. 
It is not removed entirely as it may be useful in the future to show predictions based on the `disable_ocean_mask` value, similar to the original SINR web application.