### PR TITLE
Fix colors in the app to be accessible to colorblind people.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated README with new instructions and guides on how to work with database for development
 - `save_annotation` method to save annotation with type.
 - `load_annotation` method to load the latest annotation for the given `taxa_name` and `taxa_id`.
+- Updated colors in the app to be accessible to colorblind people using the [Bang Wong](https://www.nature.com/articles/nmeth.1618) palette.
+
 
 ## [0.1.0] - 2024-07-18
 ### Added

--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -102,11 +102,11 @@ body {
 }
 
 .presence {
-  color: green;
+  color: #00b175;
 }
 
 .absence {
-  color: red;
+  color: #e14b23;
 }
 
 .switch {
@@ -147,7 +147,7 @@ body {
 }
 
 input:checked + .slider {
-  background-color: green;
+  background-color: #00b175;
 }
 
 input:checked + .slider:before {
@@ -155,7 +155,7 @@ input:checked + .slider:before {
 }
 
 input:not(:checked) + .slider {
-  background-color: red;
+  background-color: #e14b23;
 }
 
 .buttons button {
@@ -172,19 +172,19 @@ input:not(:checked) + .slider {
 }
 
 #generate_prediction {
-  background-color: #007bff;
+  background-color: #4eaee4;
 }
 
 #save_annotation {
-  background-color: #28a745;
+  background-color: #00b175;
 }
 
 #load_annotation {
-  background-color: #ffc107;
+  background-color: #eda52a;
 }
 
 #clear_annotation {
-  background-color: #dc3545;
+  background-color: #e14b23;
 }
 
 #map {
@@ -221,14 +221,14 @@ textarea:read-only {
 
 .generate-prediction {
   padding: 2px 2px;
-  background-color: #007bff;
+  background-color: #4eaee4;
   color: white;
   border: none;
 }
 
 .save-annotation {
   padding: 2px 2px;
-  background-color: #28a745;
+  background-color: #00b175;
   color: white;
   border: none;
 
@@ -236,14 +236,14 @@ textarea:read-only {
 
 .load-annotation {
   padding: 2px 2px;
-  background-color: #ffc107;
+  background-color: #eda52a;
   color: white;
   border: none;
 }
 
 .clear-annotation {
   padding: 2px 2px;
-  background-color: #dc3545;
+  background-color: #e14b23;
   color: white;
   border: none;
 }

--- a/src/frontend/src/App.js
+++ b/src/frontend/src/App.js
@@ -10,17 +10,17 @@ import "./App.css";
 const API_URL = "http://localhost:8000";
 const PATH_TO_TAXA = '/static/taxa_names.json';
 const BAR_STATUS = {
-  inactive: {loadingStatus: "", color: "#b5b5b5"},
+  inactive: {loadingStatus: "", color: "#f4f4f4"},
   generating: {loadingStatus: "Generating... This can take several seconds", color: "#b5b5b5"},
-  generatingSuccess: {loadingStatus: "Success", color: "#007bff"},
-  loadingSuccess: {loadingStatus: "Success", color: "#ffc107"},
-  saving: {loadingStatus: "Saving", color: "#b5b5b5"},
-  savingSuccess: {loadingStatus: "Saved", color: "#28a745"},
-  clearing: {loadingStatus: "Clearing", color: "#b5b5b5"},
-  clearingSuccess: {loadingStatus: "Cleared", color: "#28a745"},
-  invalid: { loadingStatus: "Invalid Taxa Name", color: "#dc3545" },
-  error: { loadingStatus: "Error checking taxa name", color: "#dc3545" },
-  failure: {loadingStatus: "Failure", color: "#dc3545"},
+  generatingSuccess: {loadingStatus: "Success", color: "#4eaee4"},
+  loadingSuccess: {loadingStatus: "Success", color: "#eda52a"},
+  saving: {loadingStatus: "Saving", color: "#f4f4f4"},
+  savingSuccess: {loadingStatus: "Saved", color: "#00b175"},
+  clearing: {loadingStatus: "Clearing", color: "#f4f4f4"},
+  clearingSuccess: {loadingStatus: "Cleared", color: "#00b175"},
+  invalid: { loadingStatus: "Invalid Taxa Name", color: "#e14b23" },
+  error: { loadingStatus: "Error checking taxa name", color: "#e14b23" },
+  failure: {loadingStatus: "Failure", color: "#e14b23"},
 };
 const BAR_TIMEOUT = 2000;
 

--- a/src/frontend/src/components/Instruction.js
+++ b/src/frontend/src/components/Instruction.js
@@ -28,15 +28,15 @@ const Instruction = () => {
                 (selected in the upper right corner of the map):</p>
               <ul>
                 <li><strong>Prediction Polygon</strong>: Predictions in the form of polygons outlining the boundaries. <b>Not editable</b>.</li>
-                <li><strong>Prediction Hexagons</strong>: Predictions in the form of hexagons (<b style={{ color: 'blue' }}>blue</b> color). <b>Not editable</b>.</li>
-                <li><strong>Current Annotation</strong>: Displays loaded predictions in <b style={{ color: 'green' }}>green</b>. <b>This is the <u>starting</u> point for annotation, available for editing.</b></li>
+                <li><strong>Prediction Hexagons</strong>: Predictions in the form of hexagons (<b style={{ color: '#4eaee4' }}>blue</b> color). <b>Not editable</b>.</li>
+                <li><strong>Current Annotation</strong>: Displays loaded predictions in <b style={{ color: '#00b175' }}>green</b>. <b>This is the <u>starting</u> point for annotation, available for editing.</b></li>
               </ul>
               An additional layer, <strong>Hexagon Grid</strong>, helps to see the grid of hexagons for more convenient marking of the annotation.
             </li>
             <br />
             <li>
               <strong className="save-annotation">Save Annotation</strong>: Clicking this button saves the
-              current annotation layer to the database (displaying it in <b style={{ color: 'green' }}>green</b>).
+              current annotation layer to the database (displaying it in <b style={{ color: '#00b175' }}>green</b>).
               <p>Before clicking this button, make sure that the annotation looks
               correct for the selected Taxa.</p>
             </li>

--- a/src/frontend/src/components/Map.js
+++ b/src/frontend/src/components/Map.js
@@ -77,7 +77,7 @@ const PredictionPolygon = ({ hullPoints }) => {
     hullPoints && (
       <Polygon
         positions={hullPoints}
-        pathOptions={{ color: "blue", fillColor: "blue" }}
+        pathOptions={{ color: "#4eaee4", fillColor: "#4eaee4" }} // blue
       />
     )
   );
@@ -104,7 +104,7 @@ const PredictionHexagons = ({ predictionHexagonIDs }) => {
     predictionHexagons && (
       <Polygon
         positions={predictionHexagons}
-        pathOptions={{ color: "blue", fillColor: "blue" }}
+        pathOptions={{ color: "#4eaee4", fillColor: "#4eaee4" }} // blue
       />
     )
   );
@@ -192,14 +192,14 @@ const Map = ({
         <LayersControl.Overlay checked name="Annotation (Presence)">
           <AnnotationHexagonsLayer
             annotationHexagonIDs={annotationHexagonIDs.presence}
-            color={"green"}
+            color={"#00b175"}
           />
         </LayersControl.Overlay>
 
         <LayersControl.Overlay checked name="Annotation (Absence)">
           <AnnotationHexagonsLayer
             annotationHexagonIDs={annotationHexagonIDs.absence}
-            color={"red"}
+            color={"#e14b23"}
           />
         </LayersControl.Overlay>
 


### PR DESCRIPTION
## Fix colors in the app to be accessible to colorblind people using the [Bang Wong](https://www.nature.com/articles/nmeth.1618) palette.

![2024-08-01_11-35](https://github.com/user-attachments/assets/7ee06fcb-b06a-4200-9db2-a21ee28487d4)

## instruction and buttons
![image](https://github.com/user-attachments/assets/f9cc638a-4a36-4978-aeab-1cbbd7e89d8d)

## prediction polygon
![image](https://github.com/user-attachments/assets/2cb9f4dc-a79e-424a-896d-ee841cac81fd)

## prediction hexagons
![image](https://github.com/user-attachments/assets/dfd578cd-3187-4cb9-8408-580eaa61a2b8)

## annotation
![image](https://github.com/user-attachments/assets/2635d4e2-bb15-4803-b439-5d51b93e5e35)
