### PR TITLE
Add the iNaturalist Observations Layer.

### DIFF
--- a/src/frontend/src/App.js
+++ b/src/frontend/src/App.js
@@ -26,6 +26,17 @@ const BAR_TIMEOUT = 2000;
 
 const DEFAULT_ANNOTATION_HEXAGON_IDS = {"presence": [], "absence": []}
 
+const getTaxonId = (taxaName) => {
+  if (taxaName) {
+    const regExp = /\(([^)]+)\)/;
+    const taxaMatch = taxaName.match(regExp);
+    if (taxaMatch) {
+      return taxaMatch[1];
+    }
+    return null;
+  }
+}
+
 function App() {
   const formRefs = {
     taxaName: useRef(null),
@@ -42,6 +53,7 @@ function App() {
   const [hexResolution, setHexResolution] = useState(4);
   const [barStatus, setBarStatus] = useState(BAR_STATUS.inactive);
   const [isPresence, setIsPresence] = useState(true);
+  const [taxonId, setTaxonId] = useState(null);
 
   const annotationType = isPresence ? "presence" : "absence"
 
@@ -76,6 +88,21 @@ function App() {
       hexResolutionInput?.removeEventListener("change", updateHexResolution);
     };
   }, [formRefs.hexResolution]);
+
+  useEffect(() => {
+    // Update the taxonId when the taxaName value changes
+    const updateTaxonId = () => {
+      const taxonId = getTaxonId(formRefs.taxaName.current.value)
+      setTaxonId(taxonId);
+    };
+
+    const taxaNameInput = formRefs.taxaName.current;
+    taxaNameInput?.addEventListener("change", updateTaxonId);
+
+    return () => {
+      taxaNameInput?.removeEventListener("change", updateTaxonId);
+    };
+  }, [formRefs.taxaName]);
 
   const checkTaxaValid = (taxa) => {
     try {
@@ -256,6 +283,7 @@ function App() {
           annotationHexagonIDs={annotationHexagonIDs}
           onAddAnnotationHexagonIDs={handleAddAnnotationHexagonIDs}
           hexResolution={hexResolution}
+          taxonId={taxonId}
         />
       </div>
     </div>

--- a/src/frontend/src/components/Map.js
+++ b/src/frontend/src/components/Map.js
@@ -145,6 +145,7 @@ const Map = ({
   annotationHexagonIDs,
   onAddAnnotationHexagonIDs,
   hexResolution,
+  taxonId,
 }) => {
   console.log('Render map');
   return (
@@ -186,6 +187,13 @@ const Map = ({
         {/* Render the Hexagon Layer */}
         <LayersControl.Overlay checked name="Hexagon Grid">
           <HexagonLayer hexResolution={hexResolution} />
+        </LayersControl.Overlay>
+
+        {/* Add the iNaturalist Observations Layer */}
+        <LayersControl.Overlay checked name="iNaturalist Observations">
+          <TileLayer
+            url={`https://tiles.inaturalist.org/v1/grid/{z}/{x}/{y}.png?taxon_id=${taxonId}`}
+          />
         </LayersControl.Overlay>
 
         {/* Custom Hexagons Layer */}


### PR DESCRIPTION
Added `iNaturalist Observations` layer to the map component, which takes user observations from the iNaturalist tiles server in the same format as it is shown on the iNaturalist website.

## [Asian Lady Beetle](https://www.inaturalist.org/taxa/48484-Harmonia-axyridis)
![image](https://github.com/user-attachments/assets/3f1b2023-37a7-4b75-a201-9a6d11cdc2a8)

## iNatator
![image](https://github.com/user-attachments/assets/f412bcf0-abce-4fe6-8f51-75f890d083c0)

