### PR TITLE
Fix info box not cleared when Taxa not selected.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `load_annotation` method to load the latest annotation for the given `taxa_name` and `taxa_id`.
 - Updated colors in the app to be accessible to colorblind people using the [Bang Wong](https://www.nature.com/articles/nmeth.1618) palette.
 
+### Fixed
+- The `Taxa Name` info box now correctly clears when an invalid taxa ID is entered.
 
 ## [0.1.0] - 2024-07-18
 ### Added

--- a/src/frontend/src/components/Sidebar.js
+++ b/src/frontend/src/components/Sidebar.js
@@ -12,14 +12,16 @@ const debounce = (func, wait) => {
 };
 
 const SHOW_DISABLE_OCEAN_MASK_CHECKBOX = false;
+const DEFAULT_SPECIES_DATA = { name: "", common_name: "" }
+const DEFAULT_IMG_URL = "/static/inat_logo_square.png"
 
 const Sidebar = forwardRef((props, ref) => {
   console.log('Render sidebar');
 
   const [, setTaxaNames] = useState([]);
-  const [speciesData, setSpeciesData] = useState({ name: "", common_name: "" });
+  const [speciesData, setSpeciesData] = useState(DEFAULT_SPECIES_DATA);
   const [taxaName, setTaxaName] = useState("");
-  const [imgURL, setImgURL] = useState("/static/inat_logo_square.png");
+  const [imgURL, setImgURL] = useState(DEFAULT_IMG_URL);
   const [updateImgURL, setUpdateImgURL] = useState(false);
 
   useEffect(() => {
@@ -38,6 +40,8 @@ const Sidebar = forwardRef((props, ref) => {
               // If not, clear the input field
               $(this).val("");
               alert("Please select a valid taxa name from the list.");
+              setSpeciesData(DEFAULT_SPECIES_DATA);
+              setImgURL(DEFAULT_IMG_URL);
             }
           },
           select: function (event, ui) {
@@ -144,10 +148,9 @@ const Sidebar = forwardRef((props, ref) => {
       <div className="taxa-info">
         <img src={imgURL} alt="species_default_image" />
         <p>
-          <span style={{ fontWeight: "bold" }}>Name:</span> {speciesData.name}
+          {speciesData.name && <span style={{ fontWeight: "bold" }}>Name:</span>} {speciesData.name}
           <br />
-          <span style={{ fontWeight: "bold" }}>Common Name:</span>{" "}
-          {speciesData.common_name}
+          {speciesData.common_name && <span style={{ fontWeight: "bold" }}>Common Name:</span>} {speciesData.common_name}
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Fixed: iNaturalist info box not cleared when Taxa not selected.

**Steps to Reproduce:**

1. Select a valid taxa ID in the "Taxa Name" drop-down. Notice that its photo and species name get loaded in the bottom left corner.
2. In the "Taxa Name" drop-down, enter an invalid taxa ID, such as "9999999999". A pop-up will appear indicating that the taxa is not valid and annotations cannot be loaded. However, the previous taxa from step 1 still appears in the bottom left.

**Fix:** The iNaturalist info box now correctly clears when an invalid taxa ID is entered.

![fix_taxa_name](https://github.com/user-attachments/assets/4a312638-c468-4cf0-a539-b8cb3361058f)


