### PR TITLE
Fix: Cleared prediction and annotation layers when changing Taxa.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - The `Taxa Name` info box now correctly clears when an invalid taxa ID is entered.
+- After changing the Taxa in the drop-down menu, the layers with predictions and annotations on the map are now cleared.
 
 ## [0.1.0] - 2024-07-18
 ### Added

--- a/src/frontend/src/App.js
+++ b/src/frontend/src/App.js
@@ -94,6 +94,10 @@ function App() {
     const updateTaxonId = () => {
       const taxonId = getTaxonId(formRefs.taxaName.current.value)
       setTaxonId(taxonId);
+      // Clear prediction and annotation layers when changing Taxa
+      setHullPoints(null);
+      setPredictionHexagonIDs(null);
+      setAnnotationHexagonIDs(DEFAULT_ANNOTATION_HEXAGON_IDS);
     };
 
     const taxaNameInput = formRefs.taxaName.current;

--- a/src/frontend/src/components/Map.js
+++ b/src/frontend/src/components/Map.js
@@ -212,10 +212,11 @@ const Map = ({
         </LayersControl.Overlay>
 
         {/* Render the PredictionHexagons if hexagons are available */}
-        <LayersControl.Overlay name="Prediction Hexagons">
-          <PredictionHexagons predictionHexagonIDs={predictionHexagonIDs} />
-        </LayersControl.Overlay>
-
+        {predictionHexagonIDs && (
+          <LayersControl.Overlay name="Prediction Hexagons">
+            <PredictionHexagons predictionHexagonIDs={predictionHexagonIDs} />
+          </LayersControl.Overlay>
+        )}
         {/* Render the PredictionPolygon if hullPoints are available */}
         {hullPoints && (
           <LayersControl.Overlay name="Prediction Polygon">


### PR DESCRIPTION
# Fixed: Prediction and annotation layers not cleared when changing Taxa.

Steps to Reproduce:

- Generate a prediction or annotate some Taxa.
- Change the Taxa in the drop-down menu.
- The prediction and annotation will remain on the map for the previous Taxa.

**Fix:** After changing the Taxa in the drop-down menu, the layers with predictions and annotations on the map are now cleared.

---
![Peek 2024-08-05 17-48](https://github.com/user-attachments/assets/8bbcbff5-9f53-46b1-9a33-9c4aa6e9c911)
