### PR TITLE
WIP Fix failed Docker build github action

### DIFF
--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -1,21 +1,18 @@
 # Use an official Node runtime as a parent image for building the React application
-FROM node:14-alpine as build
+FROM node:20-bullseye-slim as build
 
 # Set the working directory in the container to /app
 WORKDIR /app
 
-# Add the node_modules/.bin directory to the PATH for easier npm script execution
-ENV PATH /app/node_modules/.bin:$PATH
-
-# Copy the package.json and package-lock.json files to the working directory
-COPY package.json package.json
-COPY package-lock.json package-lock.json
+# Copy package.json files to the working directory
+COPY package.json .
 
 # Install dependencies using npm and install react-scripts globally with silent flag
-RUN npm install react-scripts -g --silent
+RUN npm install 
 
 # Copy the entire local directory's contents into the container at /app
-COPY . .
+COPY src/ ./src/
+COPY public/ ./public/
 
 # Build the React application
 RUN npm run build


### PR DESCRIPTION
This fixes the problem with the frontend image not building with the Docker Github action. I tested it with a v0.0.0 tag, which I will delete, and everything worked.

Changes: 
- Update the frontend Docker image to use a more recent node version
- Install all packages for build, not just react scripts
- Only copy src and public, to avoid accidentally copying node_modules or other extra files